### PR TITLE
Check Turret Vision Timeout and Other Changes

### DIFF
--- a/src/main/deploy/1100_config.json
+++ b/src/main/deploy/1100_config.json
@@ -346,8 +346,8 @@
 		{"varName" : "rollerEnabled", "value" : true},
 
 		{"varName" : "rollerSpeed", "value" : 0.7}, 
-		{"varName" : "rollerStallLimit", "value" : 80},
-		{"varName" : "rollerFreeLimit", "value" : 80},
+		{"varName" : "rollerStallLimit", "value" : 100},
+		{"varName" : "rollerFreeLimit", "value" : 100},
 
         {"varName" : "rollerUnjamSpeed", "value" : 0.5},
         {"varName" : "deployerUnjamSpeed", "value" : 0.5}, 
@@ -498,7 +498,7 @@
             "translation": {
                 "x": -0.2814828,
                 "y": 0.2814828,
-                "z": 0.2119376
+                "z": 0.244525
             },
             "angles": {
                 "pitch": -25,
@@ -514,7 +514,7 @@
             "translation": {
                 "x": -0.2814828,
                 "y": -0.2814828,
-                "z": 0.2055876
+                "z": 0.244525
             },
             "angles": {
                 "pitch": -25,

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -185,6 +185,8 @@ public final class Constants {
         public static final double kTurretMaxVelocity = 7.5;
         public static final double kBasicShooterRPM = 2000;
 
+        public static final double kTurretVisionTimeout = 4.0; //Time after which we stop trusting the turret pose without vision updates
+
         public static final double kChimneySpeed = 1.0;
 
         public static final boolean kVelocityMapQuadratic = false;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -32,7 +32,7 @@ public final class Constants {
         DEMO2,
     }
 
-    public static final ControllerLayout CONTROLLER_LAYOUT = ControllerLayout.DEBUG;
+    public static final ControllerLayout CONTROLLER_LAYOUT = ControllerLayout.COMPETITION;
 
     public static final class SwerveModuleConstants {
         public static final boolean kTurningEncoderInverted = true;

--- a/src/main/java/frc/robot/commands/shooter/ShootToPose.java
+++ b/src/main/java/frc/robot/commands/shooter/ShootToPose.java
@@ -132,7 +132,7 @@ public class ShootToPose extends Command {
             Translation3d compensatingTarget;
             if (params != null) {
                 Twist2d twist = m_Drive.getFieldRelativeTwist(params.time);//chassisSpeeds.toTwist2d(params.time);
-                compensatingTarget = target.exp(new Twist3d(twist.dx, twist.dy, 0, 0, 0, twist.dtheta)).getTranslation();
+                compensatingTarget = target.exp(new Twist3d(-twist.dx, -twist.dy, 0, 0, 0, -twist.dtheta)).getTranslation();
             } else {
                 compensatingTarget = target.getTranslation();
             }

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -158,6 +158,8 @@ public class Drive extends SubsystemBase {
 
   private final StructLogger m_poseLogger;
 
+  private double m_lastVisionUpdate;
+
   /** Creates a new Drive. */
   private Drive() {
     super("Drive");
@@ -249,6 +251,8 @@ public class Drive extends SubsystemBase {
     });
 
     m_poseLogger = StructLogger.pose2dLogger(this, "DrivePose", null);
+
+    m_lastVisionUpdate = 0;
   }
 
   public static Drive getInstance() {
@@ -350,6 +354,14 @@ public class Drive extends SubsystemBase {
    */
   public void addVisionMeasurement(Pose2d pose, double timestamp, Matrix<N3, N1> stdDevs) {
     m_DrivePoseEstimator.addVisionMeasurement(pose, timestamp, stdDevs);
+    if(timestamp > m_lastVisionUpdate)
+    {
+      m_lastVisionUpdate = timestamp;
+    }
+  }
+
+  public double getLastVisionTime() {
+    return m_lastVisionUpdate;
   }
 
   /*

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -277,7 +277,7 @@ public class Drive extends SubsystemBase {
       });
     m_poseLogger.setStruct(updated);
 
-    ChassisSpeeds currentSpeeds = getMeasuredSpeeds();
+    ChassisSpeeds currentSpeeds = getMeasuredFieldRelativeSpeeds();
     m_recentSpeeds.add(currentSpeeds);
     if (m_recentSpeeds.size() > 5) {
       m_recentSpeeds.remove(0);

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -20,6 +20,7 @@ import com.revrobotics.spark.config.SparkMaxConfig;
 import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
 
 import edu.wpi.first.math.InterpolatingMatrixTreeMap;
+import edu.wpi.first.math.MathSharedStore;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.controller.ElevatorFeedforward;
 import edu.wpi.first.math.controller.SimpleMotorFeedforward;
@@ -37,6 +38,7 @@ import edu.wpi.first.math.numbers.N2;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import frc.robot.Constants;
@@ -139,6 +141,7 @@ public class Shooter extends SubsystemBase {
     Field2d m_turretPoseField;
     private Pose3d m_turretPose;
     private boolean m_turretGotResult;
+    private double m_lastVisionUpdate;
 
     private Field2d m_trajectoryDisplay;
 
@@ -370,6 +373,8 @@ public class Shooter extends SubsystemBase {
             m_Drive.getModulePositions(), 
             new Pose3d(),
             m_robotToTurret);
+
+        m_lastVisionUpdate = 0;
 
         m_turretPoseField = new Field2d();
         new TDSendable(this, "Field", "Turret Position", m_turretPoseField);
@@ -874,6 +879,7 @@ public class Shooter extends SubsystemBase {
         Optional<VisionEstimationResult> result = Vision.getInstance().getLatestFromCamera("TurretCamera");
         if (result.isPresent()) {
             m_turretPoseEstimator.addVisionMeasurement(result.get().estimatedPose, result.get().timestamp);
+            m_lastVisionUpdate = result.get().timestamp;
 
             VisionEstimationResult turretEstimation = result.get();
 
@@ -902,8 +908,26 @@ public class Shooter extends SubsystemBase {
             m_turretGotResult = true;
         }
 
+        validateTurretLocation();
+
         m_turretPoseField.setRobotPose(m_turretPoseEstimator.getEstimatedPosition().toPose2d());
         m_turretPoseField.getObject("Hub").setPose(FieldUtils.getInstance().getHubPose().toPose2d());
+    }
+
+    private void validateTurretLocation() {
+        double now = MathSharedStore.getTimestamp();
+        if(now - m_lastVisionUpdate > Constants.ShooterConstants.kTurretVisionTimeout) {
+            double driveVisionTime = m_Drive.getLastVisionTime();
+            if(now - driveVisionTime > Constants.ShooterConstants.kTurretVisionTimeout){
+                if(FieldUtils.getInstance().isInField(m_Drive.getPose())
+                 && m_lastVisionUpdate < driveVisionTime){
+                    m_turretPoseEstimator.resetPose(new Pose3d(m_Drive.getPose()));
+                }
+            } else {
+                //This resets the underlying odometry's pose so it does want the chassis pose, not the offset turret pose
+                m_turretPoseEstimator.resetPose(new Pose3d(m_Drive.getPose()));
+            }
+        }
     }
 
     private void runHood() {

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -543,7 +543,7 @@ public class Shooter extends SubsystemBase {
         return m_robotToTurret;
     }
 
-    // TODO: mention that this positions the turret at chassis center, not turret pose
+    //This resets the underlying odometry's pose so it does want the chassis pose, not the offset turret pose
     public void resetTurretEstimatorPose(Pose3d newPose) {
         double angle = Math.toRadians(m_Drive.getGyroAngle());
         m_turretPoseEstimator.resetPosition(
@@ -680,7 +680,7 @@ public class Shooter extends SubsystemBase {
         // current target position, robot oriented
         double robotAngle = m_turretMotor.getEncoder().getPosition();
 
-        Pose2d chassisPose = m_Drive.getPose();
+        Pose2d chassisPose = m_turretPoseEstimator.getEstimatedChassisPose().toPose2d();
         Rotation2d chassisRotation = chassisPose.getRotation().plus(Rotation2d.k180deg);
         double chassisAngle = chassisRotation.getRadians();
         // current target angle, robot oriented

--- a/src/main/java/frc/robot/utils/FieldUtils.java
+++ b/src/main/java/frc/robot/utils/FieldUtils.java
@@ -248,4 +248,14 @@ public class FieldUtils{
     private final double c_fieldWidth = Constants.VisionConstants.kTagLayout.getFieldWidth();
     private final double c_trenchWidthMeters = Units.inchesToMeters(62.65); 
     private final double c_trenchToDriverStationM = Units.inchesToMeters(182.11);
+
+    public boolean isInField(Pose2d pose)
+    {
+        return (
+            pose.getX() > 0 && 
+            pose.getX() < c_fieldLength &&
+            pose.getY() > 0 &&
+            pose.getY() > c_fieldWidth
+        );
+    }
 }

--- a/src/main/java/frc/robot/utils/SwerveTurretOdometry3d.java
+++ b/src/main/java/frc/robot/utils/SwerveTurretOdometry3d.java
@@ -48,6 +48,12 @@ public class SwerveTurretOdometry3d extends SwerveDriveOdometry3d
         return update(gyroAngle, modulePositions);
     }
 
+    public Pose3d transformToChassisPose(Pose3d turretPose) {
+        Rotation3d chassisRotation = turretPose.getRotation().rotateBy(new Rotation3d(m_mostRecentTurretAngle.unaryMinus()));
+        Pose3d chassisRotatedTurretPose = new Pose3d(turretPose.getTranslation(), chassisRotation);
+        return chassisRotatedTurretPose.transformBy(m_baseToTurret.inverse());
+    }
+
     @Override
     public Pose3d getPoseMeters() {
         return super.getPoseMeters().transformBy(m_baseToTurret).transformBy(new Transform3d(new Translation3d(), new Rotation3d(m_mostRecentTurretAngle)));

--- a/src/main/java/frc/robot/utils/SwerveTurretPoseEstimator3d.java
+++ b/src/main/java/frc/robot/utils/SwerveTurretPoseEstimator3d.java
@@ -70,6 +70,11 @@ public class SwerveTurretPoseEstimator3d extends PoseEstimator3d<SwerveModulePos
     m_numModules = modulePositions.length;
   }
 
+  public Pose3d getEstimatedChassisPose() {
+    Pose3d turretPose = getEstimatedPosition();
+    return m_odometry.transformToChassisPose(turretPose);
+  }
+
   public Pose3d update(Rotation3d gyroAngle, Rotation2d turretAngle, SwerveModulePosition[] wheelPositions) {
         return updateWithTime(MathSharedStore.getTimestamp(), gyroAngle, turretAngle, wheelPositions);
     }


### PR DESCRIPTION
Adds a timeout on the turret vision that resets to the drive pose if the vision measurement is too old, or if the drive pose makes more sense.

Changes field relative angle calculation to use the turret pose rather than the Drive Subsystem pose.

Minor fixes, and constant updates